### PR TITLE
feat: show 0's instead of dashes for stats with a value of 0

### DIFF
--- a/NewPromotionStats/Src/NewPromotionStats/Classes/UIHeroPromotionStats.uc
+++ b/NewPromotionStats/Src/NewPromotionStats/Classes/UIHeroPromotionStats.uc
@@ -184,22 +184,27 @@ simulated function array<UISummary_ItemStat> GetStats()
 
 	StatsEntry.Label = class'UISoldierHeader'.default.m_strTechLabel;
 	StatsEntry.Value = GetCurrent(eStat_Hacking);
+	StatsEntry.ValueStyle = eUITextStyle_Tooltip_AbilityRight; // Prevent that zeros are converted to dashes (--)
 	Stats.AddItem(StatsEntry);
 
 	StatsEntry.Label = class'UISoldierHeader'.default.m_strArmorLabel;
 	StatsEntry.Value = GetCurrent(eStat_ArmorMitigation);
+	StatsEntry.ValueStyle = eUITextStyle_Tooltip_AbilityRight; // Prevent that zeros are converted to dashes (--)
 	Stats.AddItem(StatsEntry);
 
 	StatsEntry.Label = class'UISoldierHeader'.default.m_strDodgeLabel;
 	StatsEntry.Value = GetCurrent(eStat_Dodge);
+	StatsEntry.ValueStyle = eUITextStyle_Tooltip_AbilityRight; // Prevent that zeros are converted to dashes (--)
 	Stats.AddItem(StatsEntry);
 
 	StatsEntry.Label = class'XLocalizedData'.default.DefenseLabel;
 	StatsEntry.Value = GetCurrent(eStat_Defense);
+	StatsEntry.ValueStyle = eUITextStyle_Tooltip_AbilityRight; // Prevent that zeros are converted to dashes (--)
 	Stats.AddItem(StatsEntry);
 
 	StatsEntry.Label = class'UISoldierHeader'.default.m_strPsiLabel;
 	StatsEntry.Value = GetCurrent(eStat_PsiOffense);
+	StatsEntry.ValueStyle = eUITextStyle_Tooltip_AbilityRight; // Prevent that zeros are converted to dashes (--)
 	Stats.AddItem(StatsEntry);
 
 	return Stats;


### PR DESCRIPTION
Hey Xymanek, here's a small patch that would make the stats panel show 0's instead of dashes (--) for stats with a value of 0. I've used this when I wasn't happy with dashes showing up in my own mod that uses `UISummary_ItemStat`. I've added it only for stats that can reasonably have a value of 0.

![Screenshot from 2023-09-02 23-32-28](https://github.com/Xymanek/NewPromotionStats/assets/47794188/f4598ca6-34c9-4d2f-b513-d444b41e12aa)
